### PR TITLE
Update the reference frames for NO_TIME_DELAY

### DIFF
--- a/static/main.frag
+++ b/static/main.frag
@@ -198,7 +198,7 @@ float beamingIntensity(float abberationFactor) {
 
 /** Compute abberation factor between a normalized direction and velocity. */
 float computeAbberationFactor(vec3 dir, vec3 v) {
-    #ifdef GALILEAN
+#ifdef GALILEAN
     float gamma = 1.;
 #else
     float gamma = 1./(1. - dot(v, v));
@@ -237,14 +237,14 @@ vec4 boost(vec4 q, vec3 v) {
         return q;
     }
 #ifdef GALILEAN
-    return vec4(x - t*v, t);
+    float gamma = 1.0;
 #else
     float gamma = 1./sqrt(1. - vSq);
+#endif
     float vx = dot(v, x);
     vec3 xp = x + ((gamma - 1.) / vSq * vx - t * gamma) * v;
     float tp = gamma * (t - vx);
     return vec4(xp, tp);
-#endif
 }
 
 /** Get the relative velocity of the object in camera space. */


### PR DESCRIPTION
We need a particular `t` value to use when computing the position of a vertex that we are rendering. For the realistic model, we set `t` to be the time taken for the light to reach us from the vertex, which is just c * distance to the vertex.

For the `NO_TIME_DELAY` case, we choose a reference frame for which we consider all `t`'s to be emitted at the same time and reach the camera at the same time (since we ignore the light travel time.) We have two sensible cases: using the world as the rest frame, or the camera as the rest frame.

## Known issues

- Need to update the fragment shader with the changes made. `computeAbberationDirection` doesn't work correctly at the moment and the limit of the `boost` functions need to be recomputed.